### PR TITLE
feat:OTP is sent to user's email for 2fa

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,7 @@ SECRET_KEY=your_flask_secret_key_here
 # Database
 # This tells Flask where to create the local database file
 DATABASE_URL=sqlite:///instance/database.db
+
+# Email login for OTP
+EMAIL_USERNAME=email@gmail.com
+EMAIL_PASSWORD=email_password

--- a/backend/migrations/versions/d6004913302d_init_models.py
+++ b/backend/migrations/versions/d6004913302d_init_models.py
@@ -22,6 +22,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('email', sa.String(length=120), nullable=False),
     sa.Column('password_hash', sa.String(length=128), nullable=False),
+    sa.Column('otp_secret', sa.String(length=128), nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=True),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('email')

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -6,6 +6,7 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    otp_secret = db.Column(db.String(128), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     # Relationship to the vault
     vault_items = db.relationship('Vault', backref='owner', lazy=True)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -3,6 +3,10 @@ from flask_jwt_extended import create_access_token
 from utils.db import db
 from utils.auth import hash_password, verify_password
 from models.user import User
+import pyotp
+import smtplib
+from email.message import EmailMessage
+import os
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -18,7 +22,7 @@ def register():
     if User.query.filter_by(email=data.get('email')).first():
         return jsonify({'error': 'User already exists'}), 400
 
-    new_user = User(email=data.get('email'), password_hash=hash_password(data.get('password')))
+    new_user = User(email=data.get('email'), password_hash=hash_password(data.get('password')), otp_secret=pyotp.random_base32())
     db.session.add(new_user)
     db.session.commit()
     return jsonify({'message': 'User registered'}), 201
@@ -26,11 +30,43 @@ def register():
 @auth_bp.route('/login', methods=['POST'])
 def login():
     data = request.get_json()
-    user = User.query.filter_by(email=data.get('email')).first()
+    email = data.get('email')
+    user = User.query.filter_by(email=email).first()
     if user and verify_password(data.get('password'), user.password_hash):
+        # Generate OTP
+        totp = pyotp.TOTP(user.otp_secret, interval=600)
+        curr_otp = totp.now()
+
+        # Setup email server
+        email_server = smtplib.SMTP("smtp.gmail.com", 587)
+        email_server.starttls()
+        from_email = os.getenv("EMAIL_USERNAME")
+        email_password = os.getenv("EMAIL_PASSWORD")
+        email_server.login(from_email, email_password)
+
+        # Setup and send email
+        msg = EmailMessage()
+        msg["Subject"] = "OTP CODE"
+        msg["From"] = from_email
+        msg["To"] = email
+        msg.set_content("Your OTP is " + curr_otp + ". It will expire in 10 minutes.")
+        email_server.send_message(msg)
+
+        return jsonify({'message': 'OTP sent'}), 200
+
+    return jsonify({'error': 'Invalid credentials'}), 401
+
+@auth_bp.route('/verify-otp', methods=['POST'])
+def verify_otp():
+    data = request.get_json()
+    otp = data.get('otp')
+    user = User.query.filter_by(email=data.get('email')).first()
+
+    totp = pyotp.TOTP(user.otp_secret, interval=600)
+    if totp.verify(otp):
         token = create_access_token(identity=str(user.id))
         return jsonify({'token': token}), 200
-    return jsonify({'error': 'Invalid credentials'}), 401
+    return jsonify({'error': 'Invalid OTP'}), 401
 
 @auth_bp.route('/', methods=['GET'])
 def health_check():


### PR DESCRIPTION
Added otp_secret column in db for use in generating and verifying an OTP.
Modified /api/auth/login route to send OTP to user's email after logging in instead of return a JWT token.
Added /api/auth/verify-otp route which receives the user entered OTP and verifies it. If it is correct, the JWT token is then returned.